### PR TITLE
Rename 'nonnull' to 'non-null'

### DIFF
--- a/arrow-schema/src/datatype_display.rs
+++ b/arrow-schema/src/datatype_display.rs
@@ -15,18 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::DataType;
+use std::fmt::Display;
 use std::{collections::HashMap, fmt};
 
-use crate::DataType;
-
-impl fmt::Display for DataType {
+impl Display for DataType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn format_metadata(metadata: &HashMap<String, String>) -> String {
             format!("{}", FormatMetadata(metadata))
         }
 
         fn format_nullability(field: &crate::Field) -> &str {
-            if field.is_nullable() { "" } else { "nonnull " }
+            if field.is_nullable() { "" } else { "non-null " }
         }
 
         fn format_field(field: &crate::Field) -> String {
@@ -103,7 +103,7 @@ impl fmt::Display for DataType {
                 };
                 let metadata_str = format_metadata(field.metadata());
 
-                // e.g. `LargeList(nonnull Uint32)
+                // e.g. `LargeList(non-null Uint32)
                 write!(
                     f,
                     "{type_name}({maybe_nullable}{data_type}{field_name_str}{metadata_str})"
@@ -230,7 +230,7 @@ mod tests {
     fn test_display_list_with_named_field() {
         let list_data_type = DataType::List(Arc::new(Field::new("foo", DataType::UInt64, false)));
         let list_data_type_string = list_data_type.to_string();
-        let expected_string = "List(nonnull UInt64, field: 'foo')";
+        let expected_string = "List(non-null UInt64, field: 'foo')";
         assert_eq!(list_data_type_string, expected_string);
     }
 
@@ -239,7 +239,7 @@ mod tests {
         let list_view_data_type =
             DataType::ListView(Arc::new(Field::new("bar", DataType::UInt64, false)));
         let list_view_data_type_string = list_view_data_type.to_string();
-        let expected_string = "ListView(nonnull UInt64, field: 'bar')";
+        let expected_string = "ListView(non-null UInt64, field: 'bar')";
         assert_eq!(list_view_data_type_string, expected_string);
     }
 
@@ -250,7 +250,7 @@ mod tests {
             false,
         )));
         let nested_data_type_string = nested_data_type.to_string();
-        let nested_expected_string = "List(nonnull List(nonnull UInt64))";
+        let nested_expected_string = "List(non-null List(non-null UInt64))";
         assert_eq!(nested_data_type_string, nested_expected_string);
     }
 
@@ -261,7 +261,7 @@ mod tests {
             false,
         )));
         let nested_view_data_type_string = nested_view_data_type.to_string();
-        let nested_view_expected_string = "ListView(nonnull ListView(nonnull UInt64))";
+        let nested_view_expected_string = "ListView(non-null ListView(non-null UInt64))";
         assert_eq!(nested_view_data_type_string, nested_view_expected_string);
     }
 
@@ -300,7 +300,7 @@ mod tests {
         let large_list_named =
             DataType::LargeList(Arc::new(Field::new("bar", DataType::UInt64, false)));
         let large_list_named_string = large_list_named.to_string();
-        let expected_named_string = "LargeList(nonnull UInt64, field: 'bar')";
+        let expected_named_string = "LargeList(non-null UInt64, field: 'bar')";
         assert_eq!(large_list_named_string, expected_named_string);
 
         // Test with metadata
@@ -325,7 +325,7 @@ mod tests {
         let large_list_view_named =
             DataType::LargeListView(Arc::new(Field::new("bar", DataType::UInt64, false)));
         let large_list_view_named_string = large_list_view_named.to_string();
-        let expected_named_string = "LargeListView(nonnull UInt64, field: 'bar')";
+        let expected_named_string = "LargeListView(non-null UInt64, field: 'bar')";
         assert_eq!(large_list_view_named_string, expected_named_string);
 
         // Test with metadata
@@ -350,7 +350,7 @@ mod tests {
         let fixed_size_named =
             DataType::FixedSizeList(Arc::new(Field::new("baz", DataType::UInt64, false)), 3);
         let fixed_size_named_string = fixed_size_named.to_string();
-        let expected_named_string = "FixedSizeList(3 x nonnull UInt64, field: 'baz')";
+        let expected_named_string = "FixedSizeList(3 x non-null UInt64, field: 'baz')";
         assert_eq!(fixed_size_named_string, expected_named_string);
 
         // Test with metadata
@@ -371,7 +371,7 @@ mod tests {
         ];
         let struct_data_type = DataType::Struct(fields.into());
         let struct_data_type_string = struct_data_type.to_string();
-        let expected_string = "Struct(\"a\": nonnull Int32, \"b\": Utf8)";
+        let expected_string = "Struct(\"a\": non-null Int32, \"b\": Utf8)";
         assert_eq!(struct_data_type_string, expected_string);
 
         // Test with metadata
@@ -385,7 +385,7 @@ mod tests {
             vec![Field::new("a", DataType::Int32, false), field_with_metadata];
         let struct_data_type_with_metadata = DataType::Struct(struct_fields_with_metadata.into());
         let struct_data_type_with_metadata_string = struct_data_type_with_metadata.to_string();
-        let expected_string_with_metadata = "Struct(\"a\": nonnull Int32, \"b\": Utf8, metadata: {\"key\": \"value\", \"key2\": \"value2\"})";
+        let expected_string_with_metadata = "Struct(\"a\": non-null Int32, \"b\": Utf8, metadata: {\"key\": \"value\", \"key2\": \"value2\"})";
         assert_eq!(
             struct_data_type_with_metadata_string,
             expected_string_with_metadata
@@ -406,7 +406,7 @@ mod tests {
 
         let union_data_type = DataType::Union(union_fields, crate::UnionMode::Sparse);
         let union_data_type_string = union_data_type.to_string();
-        let expected_string = "Union(Sparse, 0: (\"a\": nonnull Int32), 1: (\"b\": Utf8))";
+        let expected_string = "Union(Sparse, 0: (\"a\": non-null Int32), 1: (\"b\": Utf8))";
         assert_eq!(union_data_type_string, expected_string);
 
         // Test with metadata
@@ -422,7 +422,7 @@ mod tests {
         let union_data_type_with_metadata =
             DataType::Union(union_fields_with_metadata, crate::UnionMode::Sparse);
         let union_data_type_with_metadata_string = union_data_type_with_metadata.to_string();
-        let expected_string_with_metadata = "Union(Sparse, 0: (\"a\": nonnull Int32), 1: (\"b\": Utf8, metadata: {\"key\": \"value\"}))";
+        let expected_string_with_metadata = "Union(Sparse, 0: (\"a\": non-null Int32), 1: (\"b\": Utf8, metadata: {\"key\": \"value\"}))";
         assert_eq!(
             union_data_type_with_metadata_string,
             expected_string_with_metadata
@@ -445,7 +445,7 @@ mod tests {
         let map_data_type = DataType::Map(Arc::new(entry_field), true);
         let map_data_type_string = map_data_type.to_string();
         let expected_string =
-            "Map(\"entries\": nonnull Struct(\"key\": nonnull Utf8, \"value\": Int32), sorted)";
+            "Map(\"entries\": non-null Struct(\"key\": non-null Utf8, \"value\": Int32), sorted)";
         assert_eq!(map_data_type_string, expected_string);
 
         // Test with metadata
@@ -464,7 +464,7 @@ mod tests {
         entry_field_with_metadata.set_metadata(metadata);
         let map_data_type_with_metadata = DataType::Map(Arc::new(entry_field_with_metadata), true);
         let map_data_type_with_metadata_string = map_data_type_with_metadata.to_string();
-        let expected_string_with_metadata = "Map(\"entries\": nonnull Struct(\"key\": nonnull Utf8, \"value\": Int32), metadata: {\"key\": \"value\"}, sorted)";
+        let expected_string_with_metadata = "Map(\"entries\": non-null Struct(\"key\": non-null Utf8, \"value\": Int32), metadata: {\"key\": \"value\"}, sorted)";
         assert_eq!(
             map_data_type_with_metadata_string,
             expected_string_with_metadata
@@ -477,7 +477,7 @@ mod tests {
         let values_field = Arc::new(Field::new("values", DataType::Int32, true));
         let ree_data_type = DataType::RunEndEncoded(run_ends_field.clone(), values_field.clone());
         let ree_data_type_string = ree_data_type.to_string();
-        let expected_string = "RunEndEncoded(\"run_ends\": nonnull UInt32, \"values\": Int32)";
+        let expected_string = "RunEndEncoded(\"run_ends\": non-null UInt32, \"values\": Int32)";
         assert_eq!(ree_data_type_string, expected_string);
 
         // Test with metadata
@@ -487,7 +487,7 @@ mod tests {
         let ree_data_type_with_metadata =
             DataType::RunEndEncoded(Arc::new(run_ends_field_with_metadata), values_field.clone());
         let ree_data_type_with_metadata_string = ree_data_type_with_metadata.to_string();
-        let expected_string_with_metadata = "RunEndEncoded(\"run_ends\": nonnull UInt32, metadata: {\"key\": \"value\"}, \"values\": Int32)";
+        let expected_string_with_metadata = "RunEndEncoded(\"run_ends\": non-null UInt32, metadata: {\"key\": \"value\"}, \"values\": Int32)";
         assert_eq!(
             ree_data_type_with_metadata_string,
             expected_string_with_metadata
@@ -515,7 +515,7 @@ mod tests {
         );
         let complex_dict_data_type_string = complex_dict_data_type.to_string();
         let expected_complex_string =
-            "Dictionary(Int16, Struct(\"a\": nonnull Int32, \"b\": Utf8))";
+            "Dictionary(Int16, Struct(\"a\": non-null Int32, \"b\": Utf8))";
         assert_eq!(complex_dict_data_type_string, expected_complex_string);
     }
 

--- a/arrow-schema/src/datatype_parse.rs
+++ b/arrow-schema/src/datatype_parse.rs
@@ -99,9 +99,9 @@ impl<'a> Parser<'a> {
     }
 
     /// parses Field, this is the inversion of `format_field` in `datatype_display.rs`.
-    /// E.g: "a": nonnull Int64
+    /// E.g: "a": non-null Int64
     ///
-    /// TODO: support metadata: `"a": nonnull Int64 metadata: {"foo": "value"}`
+    /// TODO: support metadata: `"a": non-null Int64 metadata: {"foo": "value"}`
     fn parse_field(&mut self) -> ArrowResult<Field> {
         let name = self.parse_double_quoted_string("Field")?;
         self.expect_token(Token::Colon)?;
@@ -112,9 +112,9 @@ impl<'a> Parser<'a> {
 
     /// Parses field inside a list. Use `Field::LIST_FIELD_DEFAULT_NAME`
     /// if no field name is specified.
-    /// E.g: `nonnull Int64, field: 'foo'` or `nonnull Int64`
+    /// E.g: `non-null Int64, field: 'foo'` or `non-null Int64`
     ///
-    /// TODO: support metadata: `nonnull Int64, metadata: {"foo2": "value"}`
+    /// TODO: support metadata: `non-ull Int64, metadata: {"foo2": "value"}`
     fn parse_list_field(&mut self, context: &str) -> ArrowResult<Field> {
         let nullable = self.parse_opt_nullable();
         let data_type = self.parse_next_type()?;
@@ -137,7 +137,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses the List type (called after `List` has been consumed)
-    /// E.g: List(nonnull Int64, field: 'foo')
+    /// E.g: List(non-null Int64, field: 'foo')
     fn parse_list(&mut self) -> ArrowResult<DataType> {
         self.expect_token(Token::LParen)?;
         let field = self.parse_list_field("List")?;
@@ -146,7 +146,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses the ListView type (called after `ListView` has been consumed)
-    /// E.g: ListView(nonnull Int64, field: 'foo')
+    /// E.g: ListView(non-null Int64, field: 'foo')
     fn parse_list_view(&mut self) -> ArrowResult<DataType> {
         self.expect_token(Token::LParen)?;
         let field = self.parse_list_field("ListView")?;
@@ -155,7 +155,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses the LargeList type (called after `LargeList` has been consumed)
-    /// E.g: LargeList(nonnull Int64, field: 'foo')
+    /// E.g: LargeList(non-null Int64, field: 'foo')
     fn parse_large_list(&mut self) -> ArrowResult<DataType> {
         self.expect_token(Token::LParen)?;
         let field = self.parse_list_field("LargeList")?;
@@ -164,7 +164,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses the LargeListView type (called after `LargeListView` has been consumed)
-    /// E.g: LargeListView(nonnull Int64, field: 'foo')
+    /// E.g: LargeListView(non-null Int64, field: 'foo')
     fn parse_large_list_view(&mut self) -> ArrowResult<DataType> {
         self.expect_token(Token::LParen)?;
         let field = self.parse_list_field("LargeListView")?;
@@ -175,14 +175,14 @@ impl<'a> Parser<'a> {
     /// Parses the FixedSizeList type (called after `FixedSizeList` has been consumed)
     ///
     /// Examples:
-    /// * `FixedSizeList(5 x nonnull Int64, field: 'foo')`
+    /// * `FixedSizeList(5 x non-null Int64, field: 'foo')`
     /// * `FixedSizeList(4, Int64)`
     ///
     fn parse_fixed_size_list(&mut self) -> ArrowResult<DataType> {
         self.expect_token(Token::LParen)?;
         let length = self.parse_i32("FixedSizeList")?;
         match self.next_token()? {
-            // `FixedSizeList(5 x nonnull Int64, field: 'foo')` format
+            // `FixedSizeList(5 x non-null Int64, field: 'foo')` format
             Token::X => {
                 let field = self.parse_list_field("FixedSizeList")?;
                 self.expect_token(Token::RParen)?;
@@ -464,7 +464,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses the next Union (called after `Union` has been consumed)
-    /// E.g: Union(Sparse, 0: ("a": Int32), 1: ("b": nonnull Utf8))
+    /// E.g: Union(Sparse, 0: ("a": Int32), 1: ("b": non-null Utf8))
     fn parse_union(&mut self) -> ArrowResult<DataType> {
         self.expect_token(Token::LParen)?;
         let union_mode = self.parse_union_mode()?;
@@ -501,7 +501,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses the next UnionField
-    /// 0: ("a": nonnull Int32)
+    /// 0: ("a": non-null Int32)
     fn parse_union_field(&mut self) -> ArrowResult<(i8, Field)> {
         let type_id = self.parse_i8("UnionField")?;
         self.expect_token(Token::Colon)?;
@@ -512,7 +512,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses the next Map (called after `Map` has been consumed)
-    /// E.g: Map("entries": Struct("key": Utf8, "value": nonnull Int32), sorted)
+    /// E.g: Map("entries": Struct("key": Utf8, "value": non-null Int32), sorted)
     fn parse_map(&mut self) -> ArrowResult<DataType> {
         self.expect_token(Token::LParen)?;
         let field = self.parse_field()?;
@@ -706,7 +706,7 @@ impl<'a> Tokenizer<'a> {
             "Some" => Token::Some,
             "None" => Token::None,
 
-            "nonnull" => Token::NonNull,
+            "non-null" => Token::NonNull,
             "nullable" => Token::Nullable,
             "field" => Token::Field,
             "x" => Token::X,
@@ -913,7 +913,7 @@ impl Display for Token {
                 write!(f, "{}", if *sorted { "sorted" } else { "unsorted" })
             }
             Token::RunEndEncoded => write!(f, "RunEndEncoded"),
-            Token::NonNull => write!(f, "nonnull"),
+            Token::NonNull => write!(f, "non-null"),
             Token::Nullable => write!(f, "nullable"),
             Token::Field => write!(f, "field"),
             Token::X => write!(f, "x"),

--- a/arrow-schema/src/schema.rs
+++ b/arrow-schema/src/schema.rs
@@ -726,7 +726,7 @@ mod tests {
             schema.to_string(),
             "Field { \"first_name\": Utf8, metadata: {\"k\": \"v\"} }, \
              Field { \"last_name\": Utf8 }, \
-             Field { \"address\": Struct(\"street\": nonnull Utf8, \"zip\": nonnull UInt16) }, \
+             Field { \"address\": Struct(\"street\": non-null Utf8, \"zip\": non-null UInt16) }, \
              Field { \"interests\": nullable Dictionary(Int32, Utf8), dict_id: 123, dict_is_ordered }"
         )
     }


### PR DESCRIPTION
Here is a proposed change to 
- https://github.com/apache/arrow-rs/pull/8890

It basically renames `nonnull` to `non-null` as I think that is more "proper" English grammar